### PR TITLE
Source for scraping logs from sns canisters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -487,7 +487,8 @@ sources-logs = [
   "sources-stdin",
   "sources-syslog",
   "sources-vector",
-  "sources-systemd_journal_gatewayd"
+  "sources-systemd_journal_gatewayd",
+  "sources-sns_canister"
 ]
 sources-metrics = [
   "sources-apache_metrics",
@@ -553,6 +554,7 @@ sources-utils-net-tcp = ["listenfd"]
 sources-utils-net-udp = ["listenfd"]
 sources-utils-net-unix = []
 sources-systemd_journal_gatewayd = []
+sources-sns_canister = []
 
 sources-vector = ["dep:tonic", "protobuf-build"]
 

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -70,6 +70,8 @@ pub mod postgresql_metrics;
 pub mod prometheus;
 #[cfg(feature = "sources-redis")]
 pub mod redis;
+#[cfg(feature = "sources-sns_canister")]
+pub mod sns_canister;
 #[cfg(feature = "sources-socket")]
 pub mod socket;
 #[cfg(feature = "sources-splunk_hec")]
@@ -80,10 +82,9 @@ pub mod statsd;
 pub mod syslog;
 #[cfg(feature = "sources-systemd_journal_gatewayd")]
 pub mod systemd_journal_gatewayd;
+pub mod util;
 #[cfg(feature = "sources-vector")]
 pub mod vector;
-
-pub mod util;
 
 use vector_config::{configurable_component, NamedComponent};
 use vector_core::config::{LogNamespace, Output};
@@ -94,7 +95,9 @@ use crate::config::{
     Resource, SourceConfig, SourceContext,
 };
 
-use self::systemd_journal_gatewayd::SystemdJournalGatewaydConfig;
+use self::{
+    sns_canister::SnsCanisterConfig, systemd_journal_gatewayd::SystemdJournalGatewaydConfig,
+};
 
 /// Common build errors
 #[derive(Debug, Snafu)]
@@ -303,6 +306,10 @@ pub enum Sources {
     /// Systemd-Journal-Gatewayd
     #[cfg(feature = "sources-systemd_journal_gatewayd")]
     SystemdJournalGatewayd(SystemdJournalGatewaydConfig),
+
+    /// Sns-canister
+    #[cfg(feature = "sources-sns_canister")]
+    SnsCanister(SnsCanisterConfig),
 }
 
 // We can't use `enum_dispatch` here because it doesn't support associated constants.
@@ -407,6 +414,8 @@ impl NamedComponent for Sources {
             Self::Vector(config) => config.get_component_name(),
             #[cfg(feature = "sources-systemd_journal_gatewayd")]
             Self::SystemdJournalGatewayd(config) => config.get_component_name(),
+            #[cfg(feature = "sources-sns_canister")]
+            Self::SnsCanister(config) => config.get_component_name(),
         }
     }
 }

--- a/src/sources/sns_canister.rs
+++ b/src/sources/sns_canister.rs
@@ -1,0 +1,267 @@
+//! Generalized HTTP client source.
+//! Calls an endpoint at an interval, decoding the HTTP responses into events.
+
+use crate::internal_events::{JournaldCheckpointFileOpenError, StreamClosedError};
+use crate::sources::journald::{SharedCheckpointer, StatefulCheckpointer};
+use crate::SourceSender;
+use crate::{
+    config::{SourceConfig, SourceContext},
+    sources,
+};
+use hyper::client::HttpConnector;
+use hyper::header::ACCEPT;
+use hyper::Client;
+use metrics::counter;
+use std::net::AddrParseError;
+use std::path::PathBuf;
+use std::time::Duration;
+use vector_common::internal_event::{error_stage, error_type, InternalEvent};
+use vector_common::shutdown::ShutdownSignal;
+use vector_config::configurable_component;
+use vector_core::config::{log_schema, DataType, LogNamespace, Output};
+use vector_core::event::LogEvent;
+
+const CHECKPOINT_FILENAME: &str = "checkpoint.txt";
+const BATCH_SIZE: u64 = 32;
+
+/// Configuration for the `sns_canister` source.
+#[configurable_component(source("sns_canister"))]
+#[derive(Clone, Debug, Default)]
+pub struct SnsCanisterConfig {
+    /// Canister url to collect logs from. Only base url should be specified.
+    /// Example: "http://5s2ji-faaaa-aaaaa-qaaaq-cai.ic0.app"
+    pub endpoint: String,
+
+    /// The directory used to persist checkpoints positions.
+    ///
+    /// By default, the global `data_dir` option is used. Make sure the running user has write permissions to this directory.
+    pub data_dir: Option<PathBuf>,
+}
+
+impl_generate_config_from_default!(SnsCanisterConfig);
+
+#[async_trait::async_trait]
+impl SourceConfig for SnsCanisterConfig {
+    async fn build(&self, cx: SourceContext) -> crate::Result<sources::Source> {
+        let data_dir = cx
+            .globals
+            .resolve_and_make_data_subdir(self.data_dir.as_ref(), cx.key.id())?;
+
+        let mut checkpoint_path = data_dir;
+        checkpoint_path.push(CHECKPOINT_FILENAME);
+
+        Ok(Box::pin(
+            SnsCanisterSource {
+                endpoint: self.endpoint.clone(),
+                out: cx.out,
+                checkpoint_path,
+                client: Client::builder().pool_max_idle_per_host(0).build_http(),
+            }
+            .run_shutdown(cx.shutdown),
+        ))
+    }
+
+    fn outputs(&self, _global_log_namespace: LogNamespace) -> Vec<Output> {
+        vec![Output::default(DataType::Log)]
+    }
+
+    fn can_acknowledge(&self) -> bool {
+        false
+    }
+}
+
+/// Captures the configuration options required to decode the incoming requests into events.
+#[derive(Clone)]
+struct SnsCanisterSource {
+    endpoint: String,
+    out: SourceSender,
+    checkpoint_path: PathBuf,
+    client: Client<HttpConnector>,
+}
+
+impl SnsCanisterSource {
+    async fn run_shutdown(self, shutdown: ShutdownSignal) -> Result<(), ()> {
+        let checkpointer = StatefulCheckpointer::new(self.checkpoint_path.clone())
+            .await
+            .map_err(|error| {
+                emit!(JournaldCheckpointFileOpenError {
+                    error,
+                    path: self
+                        .checkpoint_path
+                        .to_str()
+                        .unwrap_or("unknown")
+                        .to_string(),
+                });
+            })?;
+
+        let checkpointer = SharedCheckpointer::new(checkpointer);
+
+        self.run(shutdown, checkpointer).await?;
+
+        Ok(())
+    }
+
+    async fn run(
+        mut self,
+        mut shutdown: ShutdownSignal,
+        checkpointer: SharedCheckpointer,
+    ) -> Result<(), ()> {
+        let cursor = checkpointer.lock().await.cursor.clone();
+
+        let mut last_cursor = match cursor {
+            Some(val) => val,
+            None => "".to_string(),
+        };
+        let mut batch = BATCH_SIZE;
+
+        loop {
+            let url = &format!("http://{}/logs?time={}", self.endpoint, last_cursor);
+            let req = hyper::Request::builder()
+                .method(hyper::Method::GET)
+                .uri(url)
+                .header(ACCEPT, "application/json".to_string())
+                .body(hyper::Body::empty())
+                .unwrap();
+
+            let body = tokio::select! {
+                biased;
+                _ = &mut shutdown => break,
+                result = self.client.request(req) => match result {
+                    Ok(resp) => resp.into_body(),
+                    Err(_) => {
+                        warn!("Couldn't reach canister... Backing off");
+                        tokio::select! {
+                            biased;
+                            _ = &mut shutdown => break,
+                            _ = tokio::time::sleep(Duration::from_secs(5)) => continue,
+                        }
+                    }
+                }
+            };
+
+            let body_bytes = tokio::select! {
+                biased;
+                _ = &mut shutdown => break,
+                result = hyper::body::to_bytes(body) => result.map_err(|error| emit!(SnsCanisterReadError { error }))?
+            };
+
+            let body_string = String::from_utf8(body_bytes.to_vec())
+                .map_err(|error| emit!(SnsCanisterJsonError { error }))?;
+
+            let sns_logs = match serde_json::from_str::<Vec<SnsLogRecord>>(body_string.as_str()) {
+                Ok(sns_logs) => sns_logs,
+                Err(_) => {
+                    if !body_string.is_empty() {
+                        warn!("Couldn't parse log entry. Payload: \n{}", body_string);
+                    }
+                    continue;
+                }
+            };
+
+            for log in &sns_logs {
+                self.out
+                    .send_event(log.into_event())
+                    .await
+                    .map_err(|error| emit!(StreamClosedError { error, count: 1 }))?
+            }
+
+            last_cursor = match sns_logs.last() {
+                Some(log) => log.timestamp.to_string(),
+                None => last_cursor,
+            };
+            batch -= 1;
+            if batch == 0 {
+                checkpointer.lock().await.set(last_cursor.clone()).await;
+                batch = BATCH_SIZE;
+            }
+        }
+
+        checkpointer.lock().await.set(last_cursor).await;
+        Ok(())
+    }
+}
+
+#[derive(serde::Deserialize, Clone)]
+struct SnsLogRecord {
+    timestamp: String,
+    severity: String,
+    file: String,
+    line: u64,
+    message: String,
+}
+
+impl SnsLogRecord {
+    fn into_event(&self) -> LogEvent {
+        let mut log_event = LogEvent::default();
+        log_event.insert(log_schema().timestamp_key(), self.timestamp.clone());
+        log_event.insert(log_schema().message_key(), self.message.clone());
+        log_event.insert("severity", self.severity.clone());
+        log_event.insert("file", self.file.clone());
+        log_event.insert("line", self.line);
+
+        log_event
+    }
+}
+
+#[derive(Debug)]
+pub struct SnsCanisterParseUrlError {
+    pub error: AddrParseError,
+}
+
+impl InternalEvent for SnsCanisterParseUrlError {
+    fn emit(self) {
+        error!(message = "Unable to parse sns endpoint",
+            error = %self.error,
+            error_type = error_type::IO_FAILED,
+            stage = error_stage::RECEIVING,
+            internal_log_rate_limit = true,
+        );
+        counter!(
+            "component_errors_total", 1,
+            "stage" => error_stage::RECEIVING,
+            "error_type" => error_type::IO_FAILED,
+        );
+    }
+}
+
+#[derive(Debug)]
+pub struct SnsCanisterReadError {
+    pub error: hyper::Error,
+}
+
+impl InternalEvent for SnsCanisterReadError {
+    fn emit(self) {
+        error!(message = "Unable to read from endpoint",
+            error = %self.error,
+            error_type = error_type::IO_FAILED,
+            stage = error_stage::RECEIVING,
+            internal_log_rate_limit = true,
+        );
+        counter!(
+            "component_errors_total", 1,
+            "stage" => error_stage::RECEIVING,
+            "error_type" => error_type::IO_FAILED,
+        );
+    }
+}
+
+#[derive(Debug)]
+pub struct SnsCanisterJsonError {
+    pub error: std::string::FromUtf8Error,
+}
+
+impl InternalEvent for SnsCanisterJsonError {
+    fn emit(self) {
+        error!(message = "Unable to parse into json",
+            error = %self.error,
+            error_type = error_type::IO_FAILED,
+            stage = error_stage::RECEIVING,
+            internal_log_rate_limit = true,
+        );
+        counter!(
+            "component_errors_total", 1,
+            "stage" => error_stage::RECEIVING,
+            "error_type" => error_type::IO_FAILED,
+        );
+    }
+}

--- a/src/sources/sns_canister.rs
+++ b/src/sources/sns_canister.rs
@@ -20,6 +20,7 @@ use vector_config::configurable_component;
 use vector_core::config::proxy::ProxyConfig;
 use vector_core::config::{log_schema, DataType, LogNamespace, Output};
 use vector_core::event::LogEvent;
+use vector_core::tls::{TlsConfig, TlsSettings};
 
 const CHECKPOINT_FILENAME: &str = "checkpoint.txt";
 const BATCH_SIZE: u64 = 32;
@@ -50,12 +51,14 @@ impl SourceConfig for SnsCanisterConfig {
         let mut checkpoint_path = data_dir;
         checkpoint_path.push(CHECKPOINT_FILENAME);
         let proxy = ProxyConfig::from_env();
+        let default = TlsConfig::default();
+        let tls = TlsSettings::from_options(&Some(default))?;
         Ok(Box::pin(
             SnsCanisterSource {
                 endpoint: self.endpoint.clone(),
                 out: cx.out,
                 checkpoint_path,
-                client: HttpClient::new(None, &proxy)?,
+                client: HttpClient::new(tls, &proxy)?,
             }
             .run_shutdown(cx.shutdown),
         ))

--- a/src/sources/sns_canister.rs
+++ b/src/sources/sns_canister.rs
@@ -158,6 +158,11 @@ impl SnsCanisterSource {
                 }
             };
 
+            if sns_logs.len() == 0 {
+                info!("Empty batch, skipping operations...");
+                continue;
+            }
+
             for log in &sns_logs {
                 self.out
                     .send_event(log.into_event())

--- a/src/sources/sns_canister.rs
+++ b/src/sources/sns_canister.rs
@@ -129,8 +129,6 @@ impl SnsCanisterSource {
                 .body(hyper::Body::empty())
                 .unwrap();
 
-            info!("Sending request to: {}", url);
-
             let body = tokio::select! {
                 biased;
                 _ = &mut shutdown => break,
@@ -161,16 +159,10 @@ impl SnsCanisterSource {
             let sns_logs =
                 match serde_json::from_str::<SnsLogRecordsAggregated>(body_string.as_str()) {
                     Ok(sns_logs) => sns_logs,
-                    Err(_) => {
-                        if !body_string.is_empty() {
-                            warn!("Couldn't parse log entry. Payload: \n{}", body_string);
-                        }
-                        continue;
-                    }
+                    Err(_) => continue,
                 };
 
             if sns_logs.entries.len() == 0 {
-                info!("Empty batch, skipping operations...");
                 continue;
             }
 

--- a/xxx-vector.toml
+++ b/xxx-vector.toml
@@ -1,26 +1,6 @@
 [sources.in_logs_5j7vn]
 type = "sns_canister"
-endpoint = "https://5j7vn-7yaaa-aaaaa-qaaca-cai.raw.medium09.testnet.dfinity.network"
-data_dir = "logs"
-
-[sources.in_logs_5s2ji]
-type = "sns_canister"
-endpoint = "https://5s2ji-faaaa-aaaaa-qaaaq-cai.raw.medium09.testnet.dfinity.network"
-data_dir = "logs"
-
-[sources.in_logs_54yea]
-type = "sns_canister"
-endpoint = "https://54yea-6qaaa-aaaaa-qaabq-cai.raw.medium09.testnet.dfinity.network"
-data_dir = "logs"
-
-[sources.in_logs_5o6tz]
-type = "sns_canister"
-endpoint = "https://5o6tz-saaaa-aaaaa-qaacq-cai.raw.medium09.testnet.dfinity.network"
-data_dir = "logs"
-
-[sources.in_logs_53zcu]
-type = "sns_canister"
-endpoint = "https://53zcu-tiaaa-aaaaa-qaaba-cai.raw.medium09.testnet.dfinity.network"
+endpoint = "https://3e3x2-xyaaa-aaaaq-aaalq-cai.raw.ic0.app"
 data_dir = "logs"
 
 [sinks.out_logs]

--- a/xxx-vector.toml
+++ b/xxx-vector.toml
@@ -1,19 +1,31 @@
-[sources.in_logs]
-type = "systemd_journal_gatewayd"
-endpoint = "2a04:9dc0:0:108:6801:d6ff:fe59:eae1"
+[sources.in_logs_5j7vn]
+type = "sns_canister"
+endpoint = "https://5j7vn-7yaaa-aaaaa-qaaca-cai.raw.medium09.testnet.dfinity.network"
 data_dir = "logs"
-batch_size = 10
 
-# [transforms.extract_logs]
-# type = "remap"
-# inputs = ["in_logs"]
-# source = """
-# . = parse_json!(.message)
-# """
+[sources.in_logs_5s2ji]
+type = "sns_canister"
+endpoint = "https://5s2ji-faaaa-aaaaa-qaaaq-cai.raw.medium09.testnet.dfinity.network"
+data_dir = "logs"
+
+[sources.in_logs_54yea]
+type = "sns_canister"
+endpoint = "https://54yea-6qaaa-aaaaa-qaabq-cai.raw.medium09.testnet.dfinity.network"
+data_dir = "logs"
+
+[sources.in_logs_5o6tz]
+type = "sns_canister"
+endpoint = "https://5o6tz-saaaa-aaaaa-qaacq-cai.raw.medium09.testnet.dfinity.network"
+data_dir = "logs"
+
+[sources.in_logs_53zcu]
+type = "sns_canister"
+endpoint = "https://53zcu-tiaaa-aaaaa-qaaba-cai.raw.medium09.testnet.dfinity.network"
+data_dir = "logs"
 
 [sinks.out_logs]
 type = "file"
-inputs = ["in_logs"]
+inputs = ["in_logs_*"]
 compression = "none"
 path = "logs/logs.log"
     [sinks.out_logs.encoding]


### PR DESCRIPTION
Added a `sns_canister` source which can be used for scraping logs from canisters. 
Example config:
```toml
[sources.in_logs]
type = "sns_canister"
endpoint = "http://5s2ji-faaaa-aaaaa-qaaaq-cai.ic0.app"
data_dir = "logs"
```
Parameters:
* `type`: source to be executed, for us this should stay `sns_canister`, although vector has a lot of additional sources which can be checked [here](https://vector.dev/docs/reference/configuration/sources/).
* `endpoint`: base url for the canister. Note that it takes only the base url without the `/logs` which is added in the code.
* `data_dir`: base directory in which all cursors will be stored. Inside this folder there will be a folder per source (or for us canister) in which will be a single file `checkpoint.txt` where the last successfully fetched timestamp will be persisted